### PR TITLE
fixed rpc SystemChannel send on closed channel and resource port not released under abnormal shutdown

### DIFF
--- a/server/server_rpc.go
+++ b/server/server_rpc.go
@@ -263,6 +263,11 @@ func (srv *MediaServer) SystemChannel(stream rpc.MediaApi_SystemChannelServer) e
 			if err != nil {
 				break
 			}
+			_, ok := <-fromC
+			if !ok {
+				// Channel is closed
+				break
+			}
 			select {
 			case fromC <- in:
 			default:

--- a/server/session_api.go
+++ b/server/session_api.go
@@ -26,7 +26,7 @@ type MediaSession struct {
 	localIp, remoteIp     *net.IPAddr
 	localPort, remotePort uint16
 	rtpSession            *rtp.Session
-	rtpSessionLocalId	  uint32 //rtpSession id which update rtp params
+	rtpSessionLocalId     uint32 //rtpSession id which update rtp params
 	instanceId            string // which instance created this session
 
 	avPayloadNumber uint8
@@ -153,6 +153,10 @@ func (s *MediaSession) Stop() {
 		}
 		if nbDone != 3 {
 			logger.Errorf("session(%v) loops don't stop normally, finished number:%v", s.sessionId, nbDone)
+		}
+		if s.doneC != nil {
+			close(s.doneC)
+			s.doneC = nil
 		}
 	}
 

--- a/server/session_impl.go
+++ b/server/session_impl.go
@@ -181,7 +181,7 @@ func (s *MediaSession) activate() (err error) {
 	}
 	if profile := profileOfCodec(s.avPayloadCodec); profile != "" {
 		s.rtpSession.SsrcStreamOutForIndex(strLocalIdx).SetProfile(profile, byte(s.avPayloadNumber))
-		s.rtpSessionLocalId=strLocalIdx //add by sean
+		s.rtpSessionLocalId = strLocalIdx //add by sean
 	} else {
 		return errors.New("unsupported rtp payload profile")
 	}
@@ -190,23 +190,21 @@ func (s *MediaSession) activate() (err error) {
 }
 
 //author:sean. purpose:update rtp params.but does not use
-func (s* MediaSession) UpdateRtpParams() (err error){
-	if s.rtpSession==nil{
+func (s *MediaSession) UpdateRtpParams() (err error) {
+	if s.rtpSession == nil {
 		logger.Errorln("Please initialize mediaSession before update payload")
 	}
 
 	if profile := profileOfCodec(s.avPayloadCodec); profile != "" {
-		ssrcStream:=s.rtpSession.SsrcStreamOutForIndex(s.rtpSessionLocalId)
+		ssrcStream := s.rtpSession.SsrcStreamOutForIndex(s.rtpSessionLocalId)
 		ssrcStream.SetProfile(profile, byte(s.avPayloadNumber))
-		logger.Infof("update payload_number.current=%v",ssrcStream.PayloadTypeNumber())
+		logger.Infof("update payload_number.current=%v", ssrcStream.PayloadTypeNumber())
 	} else {
 		return errors.New("unsupported rtp payload profile")
 	}
 
 	return nil
 }
-
-
 
 // release all resources this session occupied
 func (s *MediaSession) finalize() {
@@ -215,6 +213,7 @@ func (s *MediaSession) finalize() {
 	}
 	if s.rtpSession != nil {
 		s.rtpSession.CloseSession()
+		s.status = sessionStatusStopped
 	}
 	if s.localPort != 0 {
 		s.server.reclaimRtpPort(s.localPort)

--- a/server/session_loop.go
+++ b/server/session_loop.go
@@ -69,6 +69,7 @@ func (s *MediaSession) receiveRtpLoop(ctx context.Context) {
 		return
 	}
 
+	s.watchdog.reportLoopInfo(receiveLoop)
 	rtpSession := s.rtpSession
 	dataReceiver := rtpSession.CreateDataReceiveChan()
 	cancelC := ctx.Done()


### PR DESCRIPTION
1.fixed rpc SystemChannel send on closed channel
2.fixed resource port not released under abnormal shutdown 
3.fixed  set closed session status sessionStatusStopped